### PR TITLE
Prepare for CocoaPod spec

### DIFF
--- a/iOS-libarchive.podspec
+++ b/iOS-libarchive.podspec
@@ -46,7 +46,6 @@ Pod::Spec.new do |s|
 
 
   s.platform     = :ios
-  s.platform     = :ios, '5.0'
 
   s.source       = { :git => "https://github.com/kballenegger/iOS-libarchive.git", :tag => "0.0.1" }
 

--- a/iOS-libarchive.podspec
+++ b/iOS-libarchive.podspec
@@ -1,0 +1,60 @@
+
+Pod::Spec.new do |s|
+
+  s.name         = "iOS-libarchive"
+  s.version      = "2.8.4"
+  s.summary      = "LibArchive Static Library for iOS"
+
+  s.description  = <<-DESC
+                   LibArchive Static Library for iOS
+                   =================================
+
+                   Unfortunately, while `libarchive.dylib` and `libbz2.dylib` are included in the
+                   iOS SDK, the header files are not. This means that they are private APIs and
+                   cannot be used if you intend to submit to the App Store.
+
+                   Never fear! This repository contains everything you need to build a static
+                   version of `libarchive` for iOS. `libbz2` is also included for extra goodness.
+
+                   To keep naming of things sane, we build the library as `libarc.a`. 
+
+                   **For iOS 4.3+** copy the header files and library from the `build-for-iOS-4.3`
+                   directory into your project.
+
+                   **For iOS 4.2** copy the header files and library from the `build-for-iOS-4.2`
+                   directory into your project.
+
+                   **If you need to build this for an earlier version of iOS**, you can easily
+                   modify the `build.sh` script to point to whatever SDKs you like. It should
+                   build fine on 3.x.
+
+                   **TO GET IT FULLY LINKING** you must also include `libz.dylib` in your list of
+                   linked libraries. To do this in XCode 4, click on your project, choose the
+                   `Build Phases` tab, go to `Link Binary With Libraries`, press `+`, and choose
+                   `libz.dylib` from the (long) list of possible libraries to link against. This
+                   is because `libarc.a` links dynamically to `libz.dylib` -- this is okay since,
+                   for whatever reason, AAPL saw fit to include the `libz` headers in the iOS SDK.
+
+                   The current `libarchive` version is `2.8.4`. The `bzlib2` version is `1.0.6`.
+                   DESC
+
+  s.homepage     = "https://github.com/kballenegger/iOS-libarchive"
+
+  s.license      = 'BSD'
+
+  s.author       = 'Kenneth Ballenegger', 'Dave Peck'
+
+
+  s.platform     = :ios
+  s.platform     = :ios, '5.0'
+
+  s.source       = { :git => "https://github.com/kballenegger/iOS-libarchive.git", :tag => "0.0.1" }
+
+
+  s.source_files  = 'libarc.a'
+
+  s.library   = 'arc'
+
+  s.xcconfig = { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/iOS-libarchive"' }
+
+end


### PR DESCRIPTION
I figured this deserves to be made into a CocoaPod. The easiest way is probably to just include it as a static library, so I've committed the built library here, with all modern architectures (armv7,7s,64,i386,x86_64).

It'd probably be better to have CocoaPods build from source, but I wanted to take the quick & easy route as a first pass…

Anyway, you don't have to merge it in, but just wanted you to be aware. :) Thanks for making open source software, @davepeck.